### PR TITLE
fixed looser throw specifier bug, appearing with gcc 4.6.3+

### DIFF
--- a/include/roboptim/trajectory/b-spline.hh
+++ b/include/roboptim/trajectory/b-spline.hh
@@ -91,7 +91,7 @@ namespace roboptim
     /// \param spline spline that will be copied
     BSpline (const BSpline<N>& spline);
 
-    virtual ~BSpline () {};
+    virtual ~BSpline () throw() {};
 
     /// \brief Modify spline parameters.
     virtual void setParameters (const vector_t&);
@@ -113,7 +113,7 @@ namespace roboptim
     ///
     /// \param o output stream used for display
     /// \return output stream
-    virtual std::ostream& print (std::ostream& o) const;
+    virtual std::ostream& print (std::ostream& o) const throw();
 
     jacobian_t variationConfigWrtParam (StableTimePoint tp) const;
     jacobian_t variationDerivWrtParam (StableTimePoint tp, size_type order)
@@ -150,11 +150,11 @@ namespace roboptim
 
     using Trajectory<N>::impl_compute;
 
-    void impl_compute (result_t&, double) const;
+    void impl_compute (result_t&, double) const throw();
     void impl_derivative (gradient_t& g, double x, size_type order)
-      const;
+      const throw();
     void impl_derivative (gradient_t& g, StableTimePoint, size_type order)
-      const;
+      const throw();
 
     vector_t basisFunctions (value_type t, size_type order) const
       ROBOPTIM_TRAJECTORY_DEPRECATED;

--- a/include/roboptim/trajectory/b-spline.hxx
+++ b/include/roboptim/trajectory/b-spline.hxx
@@ -264,7 +264,7 @@ namespace roboptim
   }
 
   template <int N>
-  void BSpline<N>::impl_compute (result_t& derivative, double t) const
+  void BSpline<N>::impl_compute (result_t& derivative, double t) const throw()
   {
     t = detail::fixTime (t, *this);
     assert (this->timeRange ().first <= t && t <= this->timeRange ().second);
@@ -353,7 +353,7 @@ namespace roboptim
   template <int N> void
   BSpline<N>::impl_derivative (gradient_t& derivative, double t,
 			       size_type order)
-    const
+    const throw()
   {
 
     t = detail::fixTime (t, *this);
@@ -389,7 +389,7 @@ namespace roboptim
   template <int N> void
   BSpline<N>::impl_derivative (gradient_t& derivative,
 			       StableTimePoint stp,
-			       size_type order) const
+			       size_type order) const throw()
   {
     this->impl_derivative (derivative,
 			   stp.getTime (this->timeRange ()),
@@ -470,7 +470,7 @@ namespace roboptim
   }
 
   template <int N> std::ostream&
-  BSpline<N>::print (std::ostream& o) const
+  BSpline<N>::print (std::ostream& o) const throw()
   {
     o << "Order " << order_ << " B-spline:" << incindent
       << iendl << "Number of parameters per spline function: " << nbp_

--- a/include/roboptim/trajectory/constrained-b-spline.hh
+++ b/include/roboptim/trajectory/constrained-b-spline.hh
@@ -55,7 +55,7 @@ namespace roboptim
 			std::string name = "Constrained B-Spline");
 
     /// \brief Destructor of constrained B-spline.
-    virtual ~ConstrainedBSpline ();
+    virtual ~ConstrainedBSpline () throw();
 
     /// Creates a constraint on the basic spline.
     /// This reduces the number of parameter by one.

--- a/include/roboptim/trajectory/constrained-b-spline.hxx
+++ b/include/roboptim/trajectory/constrained-b-spline.hxx
@@ -53,7 +53,7 @@ namespace roboptim
   {}
 
   template <int N>
-  ConstrainedBSpline<N>::~ConstrainedBSpline () {}
+  ConstrainedBSpline<N>::~ConstrainedBSpline () throw() {};
 
   template <int N>
   void ConstrainedBSpline<N>::addFixedConstraint (double t,

--- a/include/roboptim/trajectory/cubic-b-spline.hh
+++ b/include/roboptim/trajectory/cubic-b-spline.hh
@@ -53,7 +53,7 @@ namespace roboptim
     /// \param spline spline that will be copied
     CubicBSpline (const CubicBSpline& spline);
 
-    virtual ~CubicBSpline ();
+    virtual ~CubicBSpline () throw();
 
     /// \brief Modify spline parameters.
     virtual void setParameters (const vector_t&);
@@ -79,7 +79,7 @@ namespace roboptim
     ///
     /// \param o output stream used for display
     /// \return output stream
-    virtual std::ostream& print (std::ostream& o) const;
+    virtual std::ostream& print (std::ostream& o) const throw();
 
     jacobian_t variationConfigWrtParam (StableTimePoint tp) const;
     jacobian_t variationDerivWrtParam (StableTimePoint tp, size_type order)
@@ -144,11 +144,11 @@ namespace roboptim
 
   protected:
     using Trajectory<3>::impl_compute;
-    void impl_compute (result_t&, double) const;
+    void impl_compute (result_t&, double) const throw();
     void impl_derivative (gradient_t& g, double x, size_type order)
-      const;
+      const throw();
     void impl_derivative (gradient_t& g, StableTimePoint, size_type order)
-      const;
+      const throw();
 
     /// \brief Find the index of the interval in which t is.
     /// \param t instant considered.

--- a/include/roboptim/trajectory/free-time-trajectory.hh
+++ b/include/roboptim/trajectory/free-time-trajectory.hh
@@ -76,7 +76,7 @@ namespace roboptim
 
     FreeTimeTrajectory (const self_t& traj);
 
-    virtual ~FreeTimeTrajectory ();
+    virtual ~FreeTimeTrajectory () throw();
 
 
     virtual jacobian_t variationConfigWrtParam (double t) const;
@@ -106,7 +106,7 @@ namespace roboptim
     ///
     /// \param o output stream used for display
     /// \return output stream
-    virtual std::ostream& print (std::ostream& o) const;
+    virtual std::ostream& print (std::ostream& o) const throw();
 
     /// \brief Normalize angles in parameters array.
     ///
@@ -167,11 +167,11 @@ namespace roboptim
       const;
 
   protected:
-    void impl_compute (result_t&, double) const;
+    void impl_compute (result_t&, double) const throw();
     void impl_derivative (gradient_t& g, double x, size_type order)
-      const;
+      const throw();
     void impl_derivative (gradient_t& g, StableTimePoint, size_type order)
-      const;
+      const throw();
   private:
     /// \brief Input fixed time trajectory.
     fixedTimeTrajectory_t* trajectory_;

--- a/include/roboptim/trajectory/free-time-trajectory.hxx
+++ b/include/roboptim/trajectory/free-time-trajectory.hxx
@@ -64,7 +64,7 @@ namespace roboptim
   }
 
   template <typename T>
-  FreeTimeTrajectory<T>::~FreeTimeTrajectory ()
+  FreeTimeTrajectory<T>::~FreeTimeTrajectory () throw()
   {
     delete trajectory_;
   }
@@ -72,7 +72,7 @@ namespace roboptim
   template <typename T>
   void
   FreeTimeTrajectory<T>::impl_compute (result_t& res , double t)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -85,7 +85,7 @@ namespace roboptim
   void
   FreeTimeTrajectory<T>::impl_derivative (gradient_t& derivative,
 					  double t,
-					  size_type order) const
+					  size_type order) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -100,7 +100,7 @@ namespace roboptim
   void
   FreeTimeTrajectory<T>::impl_derivative (gradient_t& derivative,
 					  StableTimePoint stp,
-					  size_type order) const
+					  size_type order) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -300,7 +300,7 @@ namespace roboptim
 
   template <typename T>
   std::ostream&
-  FreeTimeTrajectory<T>::print (std::ostream& o) const
+  FreeTimeTrajectory<T>::print (std::ostream& o) const throw()
   {
     o << "Free time trajectory." << std::endl;
     return o;

--- a/include/roboptim/trajectory/frontal-speed.hh
+++ b/include/roboptim/trajectory/frontal-speed.hh
@@ -27,12 +27,12 @@ namespace roboptim
   {
   public:
     FrontalSpeed ();
-    ~FrontalSpeed ();
+    ~FrontalSpeed () throw();
 
   protected:
-    void impl_compute (result_t& res, const argument_t& t) const;
+    void impl_compute (result_t& res, const argument_t& t) const throw();
     void impl_gradient (gradient_t& grad, const argument_t& t, size_type i)
-      const;
+      const throw();
   };
 } // end of namespace roboptim.
 

--- a/include/roboptim/trajectory/orthogonal-speed.hh
+++ b/include/roboptim/trajectory/orthogonal-speed.hh
@@ -27,12 +27,12 @@ namespace roboptim
   {
   public:
     OrthogonalSpeed ();
-    ~OrthogonalSpeed ();
+    ~OrthogonalSpeed () throw();
 
   protected:
-    void impl_compute (result_t& res, const argument_t& p) const;
+    void impl_compute (result_t& res, const argument_t& p) const throw();
     void impl_gradient (gradient_t& grad, const argument_t& p, size_type i)
-      const;
+      const throw();
   };
 } // end of namespace roboptim.
 

--- a/include/roboptim/trajectory/spline-length.hh
+++ b/include/roboptim/trajectory/spline-length.hh
@@ -53,11 +53,11 @@ namespace roboptim
 		  const size_type nDiscretizationPoints = 100,
 		  boost::optional<interval_t> interval = boost::none_t ());
 
-    virtual ~SplineLength ();
+    virtual ~SplineLength () throw();
 
   protected:
-    void impl_compute (result_t&, const argument_t&) const;
-    void impl_gradient (gradient_t&, const argument_t&, size_type) const;
+    void impl_compute (result_t&, const argument_t&) const throw();
+    void impl_gradient (gradient_t&, const argument_t&, size_type) const throw();
 
   private:
     /// \brief Interval on which the length is computed.

--- a/include/roboptim/trajectory/stable-point-state-function.hh
+++ b/include/roboptim/trajectory/stable-point-state-function.hh
@@ -73,7 +73,7 @@ namespace roboptim
 			      const StableTimePoint tpt,
 			      size_type order = 1);
 
-    virtual ~StablePointStateFunction ();
+    virtual ~StablePointStateFunction () throw();
 
     size_type order () const;
 
@@ -99,9 +99,9 @@ namespace roboptim
     }
 
   protected:
-    void impl_compute (result_t&, const argument_t&) const;
+    void impl_compute (result_t&, const argument_t&) const throw();
     void impl_gradient (gradient_t&, const argument_t&, size_type)
-      const;
+      const throw();
 
   private:
     const trajectory_t& trajectory_;

--- a/include/roboptim/trajectory/stable-point-state-function.hxx
+++ b/include/roboptim/trajectory/stable-point-state-function.hxx
@@ -41,7 +41,7 @@ namespace roboptim
   }
 
   template <typename T>
-  StablePointStateFunction<T>::~StablePointStateFunction()
+  StablePointStateFunction<T>::~StablePointStateFunction() throw()
   {
   }
 
@@ -55,7 +55,7 @@ namespace roboptim
   template <typename T>
   void
   StablePointStateFunction<T>::impl_compute (result_t& res,
-				  const argument_t& p) const
+				  const argument_t& p) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -71,7 +71,7 @@ namespace roboptim
   void
   StablePointStateFunction<T>::impl_gradient (gradient_t& grad,
 				   const argument_t& p,
-				   size_type i) const
+				   size_type i) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);

--- a/include/roboptim/trajectory/state-function.hh
+++ b/include/roboptim/trajectory/state-function.hh
@@ -75,7 +75,7 @@ namespace roboptim
 		   const StableTimePoint tpt,
 		   size_type order = 1);
 
-    virtual ~StateFunction ();
+    virtual ~StateFunction () throw();
 
     size_type order () const;
 
@@ -123,9 +123,9 @@ namespace roboptim
 
 
   protected:
-    void impl_compute (result_t&, const argument_t&) const;
+    void impl_compute (result_t&, const argument_t&) const throw();
     void impl_gradient (gradient_t&, const argument_t&, size_type)
-      const;
+      const throw();
 
   private:
     const trajectory_t& trajectory_;

--- a/include/roboptim/trajectory/state-function.hxx
+++ b/include/roboptim/trajectory/state-function.hxx
@@ -49,7 +49,7 @@ namespace roboptim
   }
 
   template <typename T>
-  StateFunction<T>::~StateFunction()
+  StateFunction<T>::~StateFunction() throw()
   {
   }
 
@@ -63,7 +63,7 @@ namespace roboptim
   template <typename T>
   void
   StateFunction<T>::impl_compute (result_t& res,
-				  const argument_t& p) const
+				  const argument_t& p) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -79,7 +79,7 @@ namespace roboptim
   void
   StateFunction<T>::impl_gradient (gradient_t& grad,
 				   const argument_t& p,
-				   size_type i) const
+				   size_type i) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);

--- a/include/roboptim/trajectory/trajectory-cost.hh
+++ b/include/roboptim/trajectory/trajectory-cost.hh
@@ -48,7 +48,7 @@ namespace roboptim
     /// \param name function's name
     TrajectoryCost (const trajectory_t& traj,
 		    std::string name = std::string ());
-    virtual ~TrajectoryCost ();
+    virtual ~TrajectoryCost () throw();
   protected:
     /// \brief Input trajectory.
     const trajectory_t& trajectory_;

--- a/include/roboptim/trajectory/trajectory-cost.hxx
+++ b/include/roboptim/trajectory/trajectory-cost.hxx
@@ -29,7 +29,7 @@ namespace roboptim
   }
 
   template <typename T>
-  TrajectoryCost<T>::~TrajectoryCost ()
+  TrajectoryCost<T>::~TrajectoryCost () throw()
   {
   }
 

--- a/include/roboptim/trajectory/trajectory-sum-cost.hh
+++ b/include/roboptim/trajectory/trajectory-sum-cost.hh
@@ -150,13 +150,13 @@ namespace roboptim
 		       const discreteStableTimePointInterval_t& interval,
 		       size_type order = 1);
 
-    virtual ~TrajectorySumCost ();
+    virtual ~TrajectorySumCost () throw();
 
     size_type order () const;
 
   protected:
-    void impl_compute (result_t&, const argument_t&) const;
-    void impl_gradient (gradient_t&, const argument_t&, size_type) const;
+    void impl_compute (result_t&, const argument_t&) const throw();
+    void impl_gradient (gradient_t&, const argument_t&, size_type) const throw();
 
   private:
     const trajectory_t& trajectory_;

--- a/include/roboptim/trajectory/trajectory-sum-cost.hxx
+++ b/include/roboptim/trajectory/trajectory-sum-cost.hxx
@@ -40,7 +40,7 @@ namespace roboptim
   }
 
   template <typename T>
-  TrajectorySumCost<T>::~TrajectorySumCost()
+  TrajectorySumCost<T>::~TrajectorySumCost() throw()
   {
   }
 
@@ -54,7 +54,7 @@ namespace roboptim
   template <typename T>
   void
   TrajectorySumCost<T>::impl_compute (result_t& res,
-				      const argument_t& p) const
+				      const argument_t& p) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -84,7 +84,7 @@ namespace roboptim
   template <typename T>
   void
   TrajectorySumCost<T>::impl_gradient (gradient_t& grad, const argument_t& p,
-				       size_type i) const
+				       size_type i) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);

--- a/include/roboptim/trajectory/trajectory.hh
+++ b/include/roboptim/trajectory/trajectory.hh
@@ -97,7 +97,7 @@ namespace roboptim
     /// \brief Import interval type.
     typedef typename parent_t::interval_t interval_t;
 
-    virtual ~Trajectory ();
+    virtual ~Trajectory () throw();
 
     /// \name Accessing parameters, and state.
     /// \{
@@ -262,12 +262,12 @@ namespace roboptim
     double tolerance () const;
     /// \}
 
-    virtual std::ostream& print (std::ostream&) const;
+    virtual std::ostream& print (std::ostream&) const throw();
   protected:
-    void impl_compute (result_t&, StableTimePoint) const;
+    void impl_compute (result_t&, StableTimePoint) const throw();
     virtual void
     impl_derivative (gradient_t& g, StableTimePoint, size_type order)
-      const = 0;
+      const throw() = 0;
 
     Trajectory (interval_t, size_type, const vector_t&,
 		std::string name = std::string ());

--- a/include/roboptim/trajectory/trajectory.hxx
+++ b/include/roboptim/trajectory/trajectory.hxx
@@ -37,7 +37,7 @@ namespace roboptim
 
 
   template <unsigned dorder>
-  Trajectory<dorder>::~Trajectory ()
+  Trajectory<dorder>::~Trajectory () throw()
   {
   }
 
@@ -144,7 +144,7 @@ namespace roboptim
   template <unsigned dorder>
   void
   Trajectory<dorder>::impl_compute (result_t& res , StableTimePoint stp)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -198,7 +198,7 @@ namespace roboptim
 
   template <unsigned dorder>
   std::ostream&
-  Trajectory<dorder>::print (std::ostream& o) const
+  Trajectory<dorder>::print (std::ostream& o) const throw()
   {
     o << "Generic (abstract) trajectory." << std::endl;
     return o;

--- a/include/roboptim/trajectory/vector-interpolation.hh
+++ b/include/roboptim/trajectory/vector-interpolation.hh
@@ -52,7 +52,7 @@ namespace roboptim
     /// \throw std::runtime_error
     explicit VectorInterpolation
     (const vector_t& x, size_type outputSize, value_type dt);
-    ~VectorInterpolation ();
+    ~VectorInterpolation () throw();
 
     /// \brief Store parameters and update coefficients.
     /// \param vector_t vector of parameters.
@@ -73,12 +73,12 @@ namespace roboptim
       const;
 
   protected:
-    void impl_compute (result_t& result, double t) const;
+    void impl_compute (result_t& result, double t) const throw();
     void impl_derivative (gradient_t& derivative,
 			  double argument,
-			  size_type order = 1) const;
+			  size_type order = 1) const throw();
     void impl_derivative (gradient_t& g, StableTimePoint, size_type order)
-      const;
+      const throw();
     Trajectory<3>* resize (interval_t timeRange)
       const;
   private:

--- a/include/roboptim/trajectory/vector-interpolation.hxx
+++ b/include/roboptim/trajectory/vector-interpolation.hxx
@@ -36,14 +36,14 @@ namespace roboptim
   }
 
   inline
-  VectorInterpolation::~VectorInterpolation ()
+  VectorInterpolation::~VectorInterpolation () throw()
   {}
 
   inline
   void
   VectorInterpolation::impl_compute
   (result_t& result, double t)
-    const
+    const throw()
   {
     size_type before = static_cast<size_type> (std::floor (t / dt_));
     size_type after = static_cast<size_type> (std::ceil (t / dt_));
@@ -179,7 +179,7 @@ namespace roboptim
   VectorInterpolation::impl_derivative (gradient_t& gradient,
 					double t,
 					size_type order)
-    const
+    const throw()
   {
     size_type before = static_cast<size_type> (std::floor (t / dt_));
     size_type after = static_cast<size_type> (std::ceil (t / dt_));
@@ -214,7 +214,7 @@ namespace roboptim
   VectorInterpolation::impl_derivative (gradient_t& derivative,
 					StableTimePoint stp,
 					size_type order)
-    const
+    const throw()
   {
     this->impl_derivative
       (derivative,

--- a/src/cubic-b-spline.cc
+++ b/src/cubic-b-spline.cc
@@ -123,7 +123,7 @@ namespace roboptim
       }
   }
 
-  CubicBSpline::~CubicBSpline ()
+  CubicBSpline::~CubicBSpline () throw()
   {
   }
 
@@ -135,7 +135,7 @@ namespace roboptim
   }
 
   void
-  CubicBSpline::impl_compute (result_t& derivative, double t) const
+  CubicBSpline::impl_compute (result_t& derivative, double t) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -261,7 +261,7 @@ namespace roboptim
   void
   CubicBSpline::impl_derivative (gradient_t& derivative, double t,
 				 size_type order)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -335,7 +335,8 @@ namespace roboptim
   void
   CubicBSpline::impl_derivative (gradient_t& derivative,
 				 StableTimePoint stp,
-				 size_type order) const
+				 size_type order) 
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -418,7 +419,7 @@ namespace roboptim
   }
 
   std::ostream&
-  CubicBSpline::print (std::ostream& o) const
+  CubicBSpline::print (std::ostream& o) const throw()
   {
     o << "Cubic B-spline:" << incindent
       << iendl << "Number of parameters per spline function: " << nbp_

--- a/src/frontal-speed.cc
+++ b/src/frontal-speed.cc
@@ -28,12 +28,13 @@ namespace roboptim
   {}
 
 
-  FrontalSpeed::~FrontalSpeed ()
+  FrontalSpeed::~FrontalSpeed () throw()
   {}
 
 
   void
-  FrontalSpeed::impl_compute (result_t& res, const argument_t& x) const
+  FrontalSpeed::impl_compute (result_t& res, const argument_t& x) 
+    const throw()
   {
     const value_type& theta = x[2];
 
@@ -47,7 +48,7 @@ namespace roboptim
   FrontalSpeed::impl_gradient (gradient_t& grad,
 			       const argument_t& arg,
 			       size_type ONLY_DEBUG (i))
-    const
+    const throw()
   {
     assert (i == 0);
     //const value_type& x = arg[0];

--- a/src/orthogonal-speed.cc
+++ b/src/orthogonal-speed.cc
@@ -26,11 +26,12 @@ namespace roboptim
     : DerivableFunction (2 * 3, 1, "orthogonal speed")
   {}
 
-  OrthogonalSpeed::~OrthogonalSpeed ()
+  OrthogonalSpeed::~OrthogonalSpeed () throw()
   {}
 
   void
-  OrthogonalSpeed::impl_compute (result_t& res, const argument_t& x) const
+  OrthogonalSpeed::impl_compute (result_t& res, const argument_t& x) 
+    const throw()
   {
     const value_type& theta = x[2];
 
@@ -42,7 +43,7 @@ namespace roboptim
 
   void
   OrthogonalSpeed::impl_gradient (gradient_t& grad, const argument_t& arg, size_type)
-    const
+    const throw()
   {
     //const value_type& x = arg[0];
     //const value_type& y = arg[1];

--- a/src/spline-length.cc
+++ b/src/spline-length.cc
@@ -74,13 +74,13 @@ namespace roboptim
   {
   }
 
-  SplineLength::~SplineLength ()
+  SplineLength::~SplineLength () throw()
   {
   }
 
   void
   SplineLength::impl_compute (result_t& res, const argument_t& p)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);
@@ -101,7 +101,7 @@ namespace roboptim
   void
   SplineLength::impl_gradient (gradient_t& grad, const argument_t& p,
 			       size_type ONLY_DEBUG (i))
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
       Eigen::internal::set_is_malloc_allowed (true);

--- a/tests/cubic-b-spline.cc
+++ b/tests/cubic-b-spline.cc
@@ -46,7 +46,7 @@ struct SplineDerivWrtParameters : public DifferentiableFunction
 
   virtual void
   impl_compute (result_t& result, const argument_t& x)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -61,7 +61,7 @@ struct SplineDerivWrtParameters : public DifferentiableFunction
   impl_gradient (gradient_t& gradient,
 		 const argument_t& x,
 		 size_type functionId = 0)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);

--- a/tests/free-time-trajectory-stable-time-point.cc
+++ b/tests/free-time-trajectory-stable-time-point.cc
@@ -60,12 +60,12 @@ struct ConfigWrtParam : public DerivableFunction
   {
   }
 
-  ~ConfigWrtParam ()
+  ~ConfigWrtParam () throw()
   {
   }
 
   void
-  impl_compute (result_t& res, const argument_t& p) const
+  impl_compute (result_t& res, const argument_t& p) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -78,7 +78,7 @@ struct ConfigWrtParam : public DerivableFunction
 
   void
   impl_gradient (gradient_t& grad, const argument_t& p, size_type)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -103,11 +103,11 @@ struct DerivWrtParam : public DerivableFunction
       traj_ (traj.clone ())
   {}
 
-  ~DerivWrtParam ()
+  ~DerivWrtParam () throw()
   {}
 
   void
-  impl_compute (result_t& res, const argument_t& stp) const
+  impl_compute (result_t& res, const argument_t& stp) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -129,7 +129,7 @@ struct DerivWrtParam : public DerivableFunction
 
   void
   impl_gradient (gradient_t& grad, const argument_t& stp, size_type i)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);

--- a/tests/free-time-trajectory.cc
+++ b/tests/free-time-trajectory.cc
@@ -60,12 +60,12 @@ struct ConfigWrtParam : public DerivableFunction
   {
   }
 
-  ~ConfigWrtParam ()
+  ~ConfigWrtParam () throw()
   {
   }
 
   void
-  impl_compute (result_t& res, const argument_t& p) const
+  impl_compute (result_t& res, const argument_t& p) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -78,7 +78,7 @@ struct ConfigWrtParam : public DerivableFunction
 
   void
   impl_gradient (gradient_t& grad, const argument_t& p, size_type)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -103,11 +103,11 @@ struct DerivWrtParam : public DerivableFunction
       traj_ (traj.clone ())
   {}
 
-  ~DerivWrtParam ()
+  ~DerivWrtParam () throw()
   {}
 
   void
-  impl_compute (result_t& res, const argument_t& t) const
+  impl_compute (result_t& res, const argument_t& t) const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -119,7 +119,7 @@ struct DerivWrtParam : public DerivableFunction
 
   void
   impl_gradient (gradient_t& grad, const argument_t& t, size_type i)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);

--- a/tests/vector-interpolation.cc
+++ b/tests/vector-interpolation.cc
@@ -53,7 +53,7 @@ struct VectorInterpolationDerivWrtParameters : public DifferentiableFunction
 
   virtual void
   impl_compute (result_t& result, const argument_t& x)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);
@@ -70,7 +70,7 @@ struct VectorInterpolationDerivWrtParameters : public DifferentiableFunction
   impl_gradient (gradient_t& gradient,
 		 const argument_t& x,
 		 size_type functionId = 0)
-    const
+    const throw()
   {
 #ifndef ROBOPTIM_DO_NOT_CHECK_ALLOCATION
     Eigen::internal::set_is_malloc_allowed (true);


### PR DESCRIPTION
I couldn't compile with gcc 4.6.3 because of the looser throw specifier issue (http://bytes.com/topic/c/answers/916758-looser-throw-specifier-gcc-4-0-1-a), whereby gcc requires the definition of throw() in all derived classes, if the parent class throws errors. 

This should be backwards compatible, but i havent tested it yet. So before accepting, please make sure that it works with old versions of gcc, too. 
