### PR TITLE
Fix to allow the computing of min and max of constant polynomials

### DIFF
--- a/include/roboptim/trajectory/polynomial.hh
+++ b/include/roboptim/trajectory/polynomial.hh
@@ -186,21 +186,27 @@ namespace trajectory
 
     /// \brief Compute the minimum of the polynomial on an interval.
     /// \param interval time interval.
+    /// \param acceptConstant boolean allowing constant polynomials.
     /// \return pair containing t_min and the associated minimum of the
-    /// polynomial on the interval.
+    /// polynomial on the interval. If the polynomial is constant and
+    /// acceptConstant is not set to false, the call returns a couple of the
+    /// middle of interval and the value of the polynomial.
     /// \throw std::runtime_error invalid polynomial. This is the case for
-    /// constant polynomials since there is an infinity of critical points.
-    /// This can be tested before calling min().
-    min_t min (const interval_t& interval) const;
+    /// constant polynomials if acceptConstant is set to false, since there is
+    /// an infinity of critical points.
+    min_t min (const interval_t& interval, bool acceptConstant = true) const;
 
     /// \brief Compute the maximum of the polynomial on an interval.
     /// \param interval time interval.
+    /// \param acceptConstant boolean allowing constant polynomials.
     /// \return pair containing t_max and the associated maximum of the
-    /// polynomial on the interval.
+    /// polynomial on the interval. If the polynomial is constant and
+    /// acceptConstant is not set to false, the call returns a couple of the
+    /// middle of interval and the value of the polynomial.
     /// \throw std::runtime_error invalid polynomial. This is the case for
-    /// constant polynomials since there is an infinity of critical points.
-    /// This can be tested before calling max().
-    max_t max (const interval_t& interval) const;
+    /// constant polynomials if acceptConstant is set to false, since there is
+    /// an infinity of critical points.
+    max_t max (const interval_t& interval, bool acceptConstant = true) const;
 
     /// \brief Return whether the polynomial is null.
     /// \param epsilon epsilon used.

--- a/include/roboptim/trajectory/polynomial.hxx
+++ b/include/roboptim/trajectory/polynomial.hxx
@@ -439,8 +439,13 @@ namespace trajectory
 
   template <int N>
   typename Polynomial<N>::min_t
-  Polynomial<N>::min (const interval_t& interval) const
+  Polynomial<N>::min (const interval_t& interval, bool acceptConstant) const
   {
+    if (acceptConstant && isConstant(1e-6))
+    {
+      value_type index = (interval.first + interval.second)/2;
+      return std::make_pair(index, this->operator() (index));
+    }
     values_t crit_points = this->critPoints(interval);
 
     // Compute all the critical values + bound values
@@ -462,8 +467,13 @@ namespace trajectory
 
   template <int N>
   typename Polynomial<N>::max_t
-  Polynomial<N>::max (const interval_t& interval) const
+  Polynomial<N>::max (const interval_t& interval, bool acceptConstant) const
   {
+    if (acceptConstant && isConstant(1e-6))
+    {
+      value_type index = (interval.first + interval.second)/2;
+      return std::make_pair(index, this->operator() (index));
+    }
     values_t crit_points = this->critPoints(interval);
 
     // Compute all the critical values + bound values

--- a/tests/polynomial.cc
+++ b/tests/polynomial.cc
@@ -462,7 +462,7 @@ void test_min ()
     BOOST_CHECK_SMALL (dp (res_min.first), tol);
 
   p.coefs ().setZero ();
-  BOOST_CHECK_THROW (res_min = p.min (interval), std::runtime_error);
+  BOOST_CHECK_THROW (res_min = p.min (interval, false), std::runtime_error);
 }
 
 template <int N>
@@ -533,7 +533,7 @@ void test_max ()
     BOOST_CHECK_SMALL (dp (res_max.first), tol);
 
   p.coefs ().setZero ();
-  BOOST_CHECK_THROW (res_max = p.max (interval), std::runtime_error);
+  BOOST_CHECK_THROW (res_max = p.max (interval, false), std::runtime_error);
 }
 
 template <int N>


### PR DESCRIPTION
This commit changes the signature of min and max functions, adding a boolean to accept constant polynomials or not.
Their default behaviour is now to check if the polynomial is constant before computing the critical values.