### PR TITLE
Use boost::none instead of boost::none_t

### DIFF
--- a/include/roboptim/trajectory/spline-length.hh
+++ b/include/roboptim/trajectory/spline-length.hh
@@ -53,7 +53,7 @@ namespace trajectory
     /// \param nDiscretizationPoints number of discretization points
     SplineLength (const CubicBSpline& spline,
 		  const size_type nDiscretizationPoints = 100,
-		  boost::optional<interval_t> interval = boost::none_t ());
+		  boost::optional<interval_t> interval = boost::none);
 
     virtual ~SplineLength ();
 


### PR DESCRIPTION
The correct way to do this is to use the special tag boost::none. Default-constructing an object of that type fails to compile with Boost 1.60.0 beta1.